### PR TITLE
BREAK: ref: Expose otp struct to provider

### DIFF
--- a/main/handlers.go
+++ b/main/handlers.go
@@ -569,7 +569,7 @@ func push(otp otpgateway.OTP, tpl *providerTpl, p otpgateway.Provider, rootURL s
 		return err
 	}
 
-	return p.Push(otp.To, string(subj.Bytes()), out.Bytes())
+	return p.Push(otp, string(subj.Bytes()), out.Bytes())
 }
 
 func getURL(rootURL string, otp otpgateway.OTP, check bool) string {

--- a/main/handlers.go
+++ b/main/handlers.go
@@ -562,11 +562,16 @@ func push(otp otpgateway.OTP, tpl *providerTpl, p otpgateway.Provider, rootURL s
 		}
 	)
 
-	if err := tpl.subject.Execute(subj, data); err != nil {
-		return err
+	if tpl.subject != nil {
+		if err := tpl.subject.Execute(subj, data); err != nil {
+			return err
+		}
 	}
-	if err := tpl.tpl.Execute(out, data); err != nil {
-		return err
+
+	if tpl.tpl != nil {
+		if err := tpl.tpl.Execute(out, data); err != nil {
+			return err
+		}
 	}
 
 	return p.Push(otp, string(subj.Bytes()), out.Bytes())

--- a/provider.go
+++ b/provider.go
@@ -46,7 +46,7 @@ type Provider interface {
 	// Push pushes a message. Depending on the the Provider,
 	// implementation, this can either cause the message to
 	// be sent immediately or be queued waiting for a Flush().
-	Push(to, subject string, body []byte) error
+	Push(otp OTP, subject string, body []byte) error
 
 	// MaxAddressLen returns the maximum allowed length of the 'to' address.
 	MaxAddressLen() int

--- a/providers/pinpoint/pinpoint.go
+++ b/providers/pinpoint/pinpoint.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/pinpoint"
+	"github.com/knadh/otpgateway"
 )
 
 const (
@@ -120,14 +121,14 @@ func (s *sms) ValidateAddress(to string) error {
 }
 
 // Push pushes out an SMS.
-func (s *sms) Push(to, subject string, body []byte) error {
+func (s *sms) Push(otp otpgateway.OTP, subject string, body []byte) error {
 	var msg = string(body)
 
 	payload := &pinpoint.SendMessagesInput{
 		ApplicationId: &s.cfg.AppID,
 		MessageRequest: &pinpoint.MessageRequest{
 			Addresses: map[string]*pinpoint.AddressConfiguration{
-				sanitizePhone(to): &pinpoint.AddressConfiguration{
+				sanitizePhone(otp.To): &pinpoint.AddressConfiguration{
 					ChannelType: &channelType,
 				},
 			},

--- a/providers/solsms/solsms.go
+++ b/providers/solsms/solsms.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"regexp"
 	"time"
+
+	"github.com/knadh/otpgateway"
 )
 
 const (
@@ -118,12 +120,12 @@ func (s *sms) ValidateAddress(to string) error {
 }
 
 // Push pushes out an SMS.
-func (s *sms) Push(to, subject string, body []byte) error {
+func (s *sms) Push(otp otpgateway.OTP, subject string, body []byte) error {
 	p := url.Values{}
 	p.Set("method", "sms")
 	p.Set("api_key", s.cfg.APIKey)
 	p.Set("sender", s.cfg.Sender)
-	p.Set("to", to)
+	p.Set("to", otp.To)
 	p.Set("message", string(body))
 
 	// Make the request.


### PR DESCRIPTION
BREAKING CHANGE: Exposing OTP struct to the provider for accessing internal fields like, `Namespace`, `Extra`. Specifying a template, subject is optional now. 