### PR TITLE
feat: Add docker build in Goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,16 @@
 # .goreleaser.yml
+
+env:
+  - GO111MODULE=on
+  - CGO_ENABLED=0
+
+before:
+  hooks:
+  - make build
+
 builds:
   - binary: otpgateway
+    id: otpgateway
     main: ./cmd/otpgateway
     goos:
       - darwin
@@ -10,16 +20,32 @@ builds:
       - netbsd
     goarch:
       - amd64
-
-before:
-  hooks:
-  - make build
+    
+    hooks:
+      # stuff executables with static assets.
+      post: make pack-bin BIN={{ .Path }}
 
 archives:
   - format: tar.gz
     files:
       - static/smtp.tpl
-      - config.toml.sample
-      - smtp.prov
+      - config.sample.toml
       - README.md
       - LICENSE
+
+dockers:
+  -
+    id: otpgateway
+    goos: linux
+    goarch: amd64
+    ids:
+      - otpgateway
+    image_templates:
+      - "kailashnadh/otpgateway:{{ .Tag }}"
+      - "kailashnadh/otpgateway:latest"
+    skip_push: false
+    dockerfile: Dockerfile
+    use: docker
+    extra_files:
+      - config.sample.toml
+      - static/smtp.tpl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,6 @@
-FROM golang:1.17-alpine AS builder
-RUN apk update && apk add gcc libc-dev make git
-WORKDIR /otpgateway/
-COPY ./ ./
-ENV CGO_ENABLED=1 GOOS=linux
-RUN make deps
-RUN make build
-
-FROM alpine:latest AS deploy
-RUN apk --no-cache add ca-certificates
-WORKDIR /otpgateway/
-COPY --from=builder /otpgateway/static/ static/
-COPY --from=builder /otpgateway/otpgateway /otpgateway/config.toml.sample /otpgateway/smtp.prov /otpgateway/solsms.prov /otpgateway/pinpoint.prov ./
-RUN mkdir -p /etc/otpgateway && cp config.toml.sample /etc/otpgateway/config.toml
-VOLUME ["/etc/otpgateway"]
-CMD ["./otpgateway", "--config", "/etc/otpgateway/config.toml"]
+FROM ubuntu:20.04
+WORKDIR /app
+COPY otpgateway .
+COPY config.sample.toml config.toml
+COPY static/smtp.tpl ./static/smtp.tpl
+CMD ["./otpgateway", "--config", "./config.toml"]

--- a/Makefile
+++ b/Makefile
@@ -4,25 +4,10 @@ VERSION := $(shell git describe --abbrev=1)
 BUILDSTR := ${VERSION} (build "\\\#"${LAST_COMMIT} $(shell date '+%Y-%m-%d %H:%M:%S'))
 
 BIN := otpgateway
-SMTP_BIN := smtp.prov
-SOLSMS_BIN := solsms.prov
-PINPOINT_BIN := pinpoint.prov
 STATIC := static/
-
-CI_REGISTRY_IMAGE := kailashnadh/otpgateway
-CI_COMMIT_TAG := $(shell git tag | tail -n 1)
 
 .PHONY: build
 build:
-# 	# Compile the smtp provider plugin.
-# 	go build -ldflags="-s -w" -buildmode=plugin -o ${SMTP_BIN} provider/internal/smtp/smtp.go
-
-# 	# Compile the solsms provider plugin.
-# 	go build -ldflags="-s -w" -buildmode=plugin -o ${SOLSMS_BIN} provider/internal/solsms/solsms.go
-
-# 	# Compile the pinpoint provider plugin.
-# 	go build -ldflags="-s -w" -buildmode=plugin -o ${PINPOINT_BIN} provider/internal/pinpoint/pinpoint.go
-
 	# Compile the main application.
 	go build -o ${BIN} -ldflags="-s -w -X 'main.buildString=${BUILDSTR}'" cmd/otpgateway/*.go
 	stuffbin -a stuff -in ${BIN} -out ${BIN} ${STATIC}
@@ -39,10 +24,8 @@ clean:
 	go clean
 	- rm -f ${BIN} ${SMTP_BIN}
 
-.PHONY: docker-build
-docker-build:
-	docker build -t ${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG} .
-
-.PHONY: docker-push
-docker-push:
-	docker push ${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG}
+# pack-releases runns stuffbin packing on the given binary. This is used
+# in the .goreleaser post-build hook.
+.PHONY: pack-bin
+pack-bin: build $(BIN) $(STUFFBIN)
+	$(STUFFBIN) -a stuff -in ${BIN} -out ${BIN} ${STATIC}


### PR DESCRIPTION
- Changed the `Dockerfile` to be used only with `goreleaser`
- Added a `pack-bin` target in `Makefile` (this is used by `goreleaser` else the binary it produces doesn't have stuffed files.)
- Cleaned up unused targets/references in `Makefile`
