### PR TITLE
feat: Add ca-certificates in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:20.04
+RUN apt update && apt install -y ca-certificates
 WORKDIR /app
 COPY otpgateway .
 COPY config.sample.toml config.toml


### PR DESCRIPTION
Absence of ca-certificates in the docker image leads to `net/http.Client` complaining about missing certs and not properly authenticate SSL connections (`x509 certificate signed by unknown authority`)