### PR TITLE
fix: Use timeout in config.sample.toml

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -89,7 +89,7 @@ api_key = ""
 default_phone_code = "+91"
 
 max_conns = 10
-request_timeout = "5s"
+timeout = "5s"
 
 
 
@@ -109,7 +109,7 @@ default_phone_code = "+91"
 template_name = "otp"
 
 max_conns = 10
-request_timeout = "5s"
+timeout = "5s"
 
 
 
@@ -143,7 +143,7 @@ enabled = false
 
 url = "https://your-webhook-endpoint:8000"
 max_conns = 10
-request_timeout = "5s"
+timeout = "5s"
 
 # BasicAuth (Authorization header) credentials to post to the URL.
 username = ""


### PR DESCRIPTION
The sample config uses `request_timeout` but the actual value of the config key is `timeout`.