### PR TITLE
feat: Add a DELETE handler to check status and delete otp if verified

### DIFF
--- a/cmd/otpgateway/handlers.go
+++ b/cmd/otpgateway/handlers.go
@@ -271,6 +271,11 @@ func handleCheckOTPStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if out.Closed {
+		// Delete otp
+		if r.Method == http.MethodDelete {
+			app.store.Delete(namespace, id)
+		}
+
 		sendResponse(w, out)
 		return
 	}

--- a/cmd/otpgateway/main.go
+++ b/cmd/otpgateway/main.go
@@ -79,6 +79,7 @@ func main() {
 	r.Get("/api/health", wrap(app, handleHealthCheck))
 	r.Put("/api/otp/{id}", auth(authCreds, wrap(app, handleSetOTP)))
 	r.Post("/api/otp/{id}/status", auth(authCreds, wrap(app, handleCheckOTPStatus)))
+	r.Delete("/api/otp/{id}/status", auth(authCreds, wrap(app, handleCheckOTPStatus)))
 	r.Post("/api/otp/{id}", auth(authCreds, wrap(app, handleVerifyOTP)))
 
 	r.Get("/otp/{namespace}/{id}", wrap(app, handleOTPView))


### PR DESCRIPTION
* This allows backend check to delete the otp if it is already verified without using verify otp handler which requires keeping otp number in its state.