### PR TITLE
feat: add custom attributes in pinpoint

### DIFF
--- a/internal/providers/pinpoint/pinpoint.go
+++ b/internal/providers/pinpoint/pinpoint.go
@@ -139,6 +139,9 @@ func (p *PinpointSMS) Push(otp models.OTP, subject string, body []byte) error {
 					ChannelType: types.ChannelTypeSms,
 				},
 			},
+			Context: map[string]string{
+				"namespace": otp.Namespace,
+			},
 			MessageConfiguration: &types.DirectMessageConfiguration{
 				SMSMessage: &types.SMSMessage{
 					Body:        aws.String(string(body)),


### PR DESCRIPTION
Pinpoint SMS provider supports arbitary params to be sent which can be added to email/SMS delivery receipt event attributes.

This change will help us log the `namespace` which sent the OTP while consuming the SMS events stream: https://docs.aws.amazon.com/pinpoint/latest/developerguide/event-streams-data-sms.html 