### PR TITLE
fix: update new template category name for auth sms

### DIFF
--- a/internal/providers/kaleyra/kaleyra.go
+++ b/internal/providers/kaleyra/kaleyra.go
@@ -120,11 +120,11 @@ func (k *Kaleyra) Push(otp models.OTP, subject string, body []byte) error {
 		p.Set("template_id", k.cfg.SMSTemplateID)
 		p.Set("body", string(body))
 	} else {
-		p.Set("type", "template")
+		p.Set("type", "authenticationtemplate")
 		p.Set("channel", "whatsapp")
 		p.Set("from", k.cfg.Sender)
 		p.Set("template_name", k.cfg.TemplateName)
-		p.Set("params", fmt.Sprintf(`"%s"`, otp.OTP))
+		p.Set("verification_code", otp.OTP)
 	}
 
 	// Make the request.


### PR DESCRIPTION
- Updated the Kaleyra WhatsApp provider to use authentication templates
- Switched from a generic `params` field to a specific `verification_code` parameter.

This aligns with WhatsApp's OTP message requirements.

