### PR TITLE
fix: Return store error from verifyOTP when OTP is missing in store

### DIFF
--- a/cmd/otpgateway/handlers.go
+++ b/cmd/otpgateway/handlers.go
@@ -534,11 +534,11 @@ func verifyOTP(namespace, id, otp string, deleteOnVerify bool, app *App) (models
 	// Check the OTP.
 	out, err := app.store.Check(namespace, id, store.CounterAttempts)
 	if err != nil {
-		if err != store.ErrNotExist {
-			app.lo.Error("error checking OTP", "error", err)
-			return out, err
+		if err == store.ErrNotExist {
+			return out, store.ErrNotExist
 		}
-		return out, errors.New("error checking OTP.")
+		app.lo.Error("error checking OTP", "error", err)
+		return out, errors.New("error checking OTP")
 	}
 
 	errMsg := ""

--- a/cmd/otpgateway/handlers_test.go
+++ b/cmd/otpgateway/handlers_test.go
@@ -235,6 +235,14 @@ func TestCheckOTP(t *testing.T) {
 	// Check it again. Should be deleted.
 	r = testRequest(t, http.MethodPost, "/api/otp/"+dummyOTPID, cp, &data)
 	assert.NotEqual(t, http.StatusOK, r.StatusCode, "OTP didn't get deleted on verification")
+
+	// Check non-existent OTP, should not return 200.
+	r = testRequest(t, http.MethodPost, "/api/otp/abc123", cp, &data)
+	assert.NotEqual(t, http.StatusOK, r.StatusCode, "non-existent OTP didn't return 400")
+
+	// Check non-existent OTP, should return store.ErrNotExist error message.
+	_ = testRequest(t, http.MethodPost, "/api/otp/abc123", cp, &out)
+	assert.Equal(t, "the OTP does not exist", out.Message, "non-existent OTP passed")
 }
 
 func TestCheckOTPAttempts(t *testing.T) {


### PR DESCRIPTION
When OTP record's missing in the store, the UI would end up showing this error message on action `check`: 
"Internal error"
"The provider for this OTP was not found."

Now verifyOTP returns a store-level not-found error which is mapped to the "Session expired" message.

Added test cases for the same.