### PR TITLE
fix: return apt 410 Gone status code and error message when OTP no longer exists in the store.

### DIFF
--- a/cmd/otpgateway/handlers.go
+++ b/cmd/otpgateway/handlers.go
@@ -273,7 +273,7 @@ func handleCheckOTPStatus(w http.ResponseWriter, r *http.Request) {
 	out, err := app.store.Check(namespace, id, store.CounterNil)
 	if err != nil {
 		if err == store.ErrNotExist {
-			sendErrorResponse(w, err.Error(), http.StatusBadRequest, nil)
+			sendErrorResponse(w, "OTP has expired.", http.StatusGone, nil)
 			return
 		}
 
@@ -318,7 +318,7 @@ func handleVerifyOTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		code := http.StatusBadRequest
 		if err == store.ErrNotExist {
-			sendErrorResponse(w, err.Error(), code, nil)
+			sendErrorResponse(w, "OTP has expired.", http.StatusGone, nil)
 			return
 		}
 

--- a/cmd/otpgateway/handlers.go
+++ b/cmd/otpgateway/handlers.go
@@ -273,7 +273,7 @@ func handleCheckOTPStatus(w http.ResponseWriter, r *http.Request) {
 	out, err := app.store.Check(namespace, id, store.CounterNil)
 	if err != nil {
 		if err == store.ErrNotExist {
-			sendErrorResponse(w, "OTP has expired.", http.StatusGone, nil)
+			sendErrorResponse(w, err.Error(), http.StatusGone, nil)
 			return
 		}
 
@@ -318,7 +318,7 @@ func handleVerifyOTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		code := http.StatusBadRequest
 		if err == store.ErrNotExist {
-			sendErrorResponse(w, "OTP has expired.", http.StatusGone, nil)
+			sendErrorResponse(w, err.Error(), http.StatusGone, nil)
 			return
 		}
 

--- a/cmd/otpgateway/handlers.go
+++ b/cmd/otpgateway/handlers.go
@@ -273,7 +273,7 @@ func handleCheckOTPStatus(w http.ResponseWriter, r *http.Request) {
 	out, err := app.store.Check(namespace, id, store.CounterNil)
 	if err != nil {
 		if err == store.ErrNotExist {
-			sendErrorResponse(w, err.Error(), http.StatusGone, nil)
+			sendErrorResponse(w, err.Error(), http.StatusBadRequest, nil)
 			return
 		}
 

--- a/cmd/otpgateway/handlers_test.go
+++ b/cmd/otpgateway/handlers_test.go
@@ -243,7 +243,7 @@ func TestCheckOTP(t *testing.T) {
 	// Check non-existent OTP, should return 410.
 	r = testRequest(t, http.MethodPost, "/api/otp/abc123", cp, &out)
 	assert.Equal(t, http.StatusGone, r.StatusCode, "non-existent OTP returns 410")
-	assert.Equal(t, "OTP has expired.", out.Message, "non-existent OTP passed")
+	assert.Equal(t, "OTP has expired or doesn't exist", out.Message, "non-existent OTP passed")
 }
 
 func TestCheckOTPAttempts(t *testing.T) {
@@ -325,7 +325,7 @@ func TestDeleteOnOTPCheck(t *testing.T) {
 	// Reattempt status check
 	r = testRequest(t, http.MethodDelete, "/api/otp/"+dummyOTPID+"/status", nil, &out)
 	assert.Equal(t, http.StatusGone, r.StatusCode, "otp not found returns 410")
-	assert.Equal(t, "OTP has expired.", out.Message, "deleted OTP passed")
+	assert.Equal(t, "OTP has expired or doesn't exist", out.Message, "deleted OTP passed")
 }
 
 func testRequest(t *testing.T, method, path string, p url.Values, out interface{}) *http.Response {

--- a/cmd/otpgateway/handlers_test.go
+++ b/cmd/otpgateway/handlers_test.go
@@ -238,11 +238,12 @@ func TestCheckOTP(t *testing.T) {
 
 	// Check non-existent OTP, should not return 200.
 	r = testRequest(t, http.MethodPost, "/api/otp/abc123", cp, &data)
-	assert.NotEqual(t, http.StatusOK, r.StatusCode, "non-existent OTP didn't return 400")
+	assert.NotEqual(t, http.StatusOK, r.StatusCode, "non-existent OTP didn't return 200")
 
-	// Check non-existent OTP, should return store.ErrNotExist error message.
-	_ = testRequest(t, http.MethodPost, "/api/otp/abc123", cp, &out)
-	assert.Equal(t, "the OTP does not exist", out.Message, "non-existent OTP passed")
+	// Check non-existent OTP, should return 400.
+	r = testRequest(t, http.MethodPost, "/api/otp/abc123", cp, &out)
+	assert.Equal(t, http.StatusGone, r.StatusCode, "non-existent OTP returns 410")
+	assert.Equal(t, "OTP has expired.", out.Message, "non-existent OTP passed")
 }
 
 func TestCheckOTPAttempts(t *testing.T) {
@@ -322,8 +323,9 @@ func TestDeleteOnOTPCheck(t *testing.T) {
 	assert.Equal(t, http.StatusOK, r.StatusCode, "verification pending")
 
 	// Reattempt status check
-	r = testRequest(t, http.MethodDelete, "/api/otp/"+dummyOTPID+"/status", nil, &data)
-	assert.Equal(t, http.StatusBadRequest, r.StatusCode, "otp not found")
+	r = testRequest(t, http.MethodDelete, "/api/otp/"+dummyOTPID+"/status", nil, &out)
+	assert.Equal(t, http.StatusGone, r.StatusCode, "otp not found returns 410")
+	assert.Equal(t, "OTP has expired.", out.Message, "deleted OTP passed")
 }
 
 func testRequest(t *testing.T, method, path string, p url.Values, out interface{}) *http.Response {

--- a/cmd/otpgateway/handlers_test.go
+++ b/cmd/otpgateway/handlers_test.go
@@ -240,7 +240,7 @@ func TestCheckOTP(t *testing.T) {
 	r = testRequest(t, http.MethodPost, "/api/otp/abc123", cp, &data)
 	assert.NotEqual(t, http.StatusOK, r.StatusCode, "non-existent OTP didn't return 200")
 
-	// Check non-existent OTP, should return 400.
+	// Check non-existent OTP, should return 410.
 	r = testRequest(t, http.MethodPost, "/api/otp/abc123", cp, &out)
 	assert.Equal(t, http.StatusGone, r.StatusCode, "non-existent OTP returns 410")
 	assert.Equal(t, "OTP has expired.", out.Message, "non-existent OTP passed")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -8,7 +8,7 @@ import (
 
 // ErrNotExist is thrown when an OTP (requested by namespace / ID)
 // does not exist.
-var ErrNotExist = errors.New("the OTP does not exist")
+var ErrNotExist = errors.New("OTP has expired or doesn't exist")
 
 const (
 	CounterAttempts = "attempts"


### PR DESCRIPTION
When an OTP is no longer available in the store, the system currently returns a 400 Bad Request status. This creates an uncertainty between an invalid OTP input and an OTP that has expired or been removed. PR changes the response status code to return 410 Gone when the OTP is no longer available.